### PR TITLE
removing warn: You (or an addon) are using the 'config' preset field.…

### DIFF
--- a/preset.js
+++ b/preset.js
@@ -1,7 +1,7 @@
-function config(entry = []) {
+function previewAnnotations(entry = []) {
   return [...entry, require.resolve('./dist/esm/preset/preview')];
 }
 
 module.exports = {
-  config,
+  previewAnnotations,
 };


### PR DESCRIPTION
Eliminated warning: WARN You (or an addon) are using the 'config' preset field. This has been replaced by 'previewAnnotations' and will be removed in 8.0
Very similar to https://github.com/storybookjs/storybook/issues/23327