### PR TITLE
fix: Add fallback value to parameters to avoid TypeError

### DIFF
--- a/src/withFetchMock.ts
+++ b/src/withFetchMock.ts
@@ -43,9 +43,9 @@ export const withFetchMock = makeDecorator({
   //   reset fetch-mock.
   skipIfNoParametersOrOptions: false,
 
-  wrapper(storyFn, context, { parameters }) {
+  wrapper(storyFn, context, { parameters = {} }) {
     // If requested, send debug info to the console.
-    if (fetchMock.called() && parameters && parameters.debug) {
+    if (fetchMock.called() && parameters.debug) {
       // Construct an object that easy to navigate in the console.
       const calls: { [key: string]: MockCall } = {};
       fetchMock.calls().forEach((call) => {


### PR DESCRIPTION
The parameters might receive an undefined value. This causes runtime errors that are fatal to storybook. Adding a fallback to an empty object avoids these errors. Additionally, we can now elide further truthiness checks on parameters.