### PR TITLE
fix: Change peer dependency from exact version for @storybook/preview-api

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
     "fetch-mock": "^9.11.0"
   },
   "peerDependencies": {
-    "@storybook/preview-api": "^7.0.0 || 8.0.0 || next"
+    "@storybook/preview-api": "^7.0.0 || ^8.0.0 || next"
   },
   "devDependencies": {
     "@storybook/preview-api": "^8.0.0",


### PR DESCRIPTION
@storybook/preview-api has an exact version of 8.0.0, this changes it to ^8.0.0